### PR TITLE
Fix NoSuchElementException

### DIFF
--- a/src/main/java/de/chafficplugins/mininglevels/listeners/events/MiningEvents.java
+++ b/src/main/java/de/chafficplugins/mininglevels/listeners/events/MiningEvents.java
@@ -13,7 +13,6 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockDamageEvent;
-import org.bukkit.event.EventPriority;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -67,7 +66,7 @@ public class MiningEvents implements Listener {
         return plugin.getConfig().getStringList(MINING_ITEMS).contains(material.name());
     }
 
-    @EventHandler(priority = EventPriority.LOWEST)
+    @EventHandler
     public void onBlockBreak(final BlockBreakEvent event) {
         final MiningBlock block = MiningBlock.getMiningBlock(event.getBlock().getType());
         sendDebug(event.getPlayer(), "BlockBreakEvent: " + event.getBlock().getType().name());

--- a/src/main/java/de/chafficplugins/mininglevels/listeners/events/MiningEvents.java
+++ b/src/main/java/de/chafficplugins/mininglevels/listeners/events/MiningEvents.java
@@ -99,11 +99,12 @@ public class MiningEvents implements Listener {
                         }
                         miningPlayer.alterXp(block.getXp());
                         MiningLevel level = miningPlayer.getLevel();
-                        
-                        if (actualBlock.getDrops().isEmpty()) {return;}
 
                         if (MathUtils.randomDouble(0, 100) < level.getExtraOreProbability()) {
                             Block actualBlock = event.getBlock();
+
+                            if (actualBlock.getDrops().isEmpty()) {return;}
+
                             int amount = (int) MathUtils.randomDouble(1, level.getMaxExtraOre());
                             ItemStack item = actualBlock.getDrops().iterator().next();
                             for (int i = 0; i < amount; i++) {

--- a/src/main/java/de/chafficplugins/mininglevels/listeners/events/MiningEvents.java
+++ b/src/main/java/de/chafficplugins/mininglevels/listeners/events/MiningEvents.java
@@ -98,6 +98,8 @@ public class MiningEvents implements Listener {
                         }
                         miningPlayer.alterXp(block.getXp());
                         MiningLevel level = miningPlayer.getLevel();
+                        
+                        if (actualBlock.getDrops().isEmpty()) {return;}
 
                         if (MathUtils.randomDouble(0, 100) < level.getExtraOreProbability()) {
                             Block actualBlock = event.getBlock();

--- a/src/main/java/de/chafficplugins/mininglevels/listeners/events/MiningEvents.java
+++ b/src/main/java/de/chafficplugins/mininglevels/listeners/events/MiningEvents.java
@@ -13,6 +13,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockDamageEvent;
+import org.bukkit.event.EventPriority;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -66,7 +67,7 @@ public class MiningEvents implements Listener {
         return plugin.getConfig().getStringList(MINING_ITEMS).contains(material.name());
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.LOWEST)
     public void onBlockBreak(final BlockBreakEvent event) {
         final MiningBlock block = MiningBlock.getMiningBlock(event.getBlock().getType());
         sendDebug(event.getPlayer(), "BlockBreakEvent: " + event.getBlock().getType().name());
@@ -106,7 +107,7 @@ public class MiningEvents implements Listener {
                             int amount = (int) MathUtils.randomDouble(1, level.getMaxExtraOre());
                             ItemStack item = actualBlock.getDrops().iterator().next();
                             for (int i = 0; i < amount; i++) {
-                                event.getPlayer().getWorld().dropItemNaturally(actualBlock.getLocation(), item);
+                                actualBlock.getDrops().add(item);
                             }
                             sendDebug(event.getPlayer(), "BlockBreakEvent: " + "Dropped " + amount + " extra ores.");
                         }


### PR DESCRIPTION
Line 105 (107 after pull request) pulls the next item from an iterator of block drop ItemStacks. However, if the drops are empty, it creates a NoSuchElementException. All this code does is return if the list is empty so it doesn't error in console, just skipping the drop multiplying code (no need to try and multiply nothing!)