### PR TITLE
ci: upload plugin JAR as build artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,19 @@ jobs:
       - name: Build and test
         run: mvn -B clean verify --file pom.xml
 
+      - name: Get project version
+        id: version
+        run: echo "VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> "$GITHUB_OUTPUT"
+
+      - name: Rename JAR for release
+        run: cp target/MiningLevels-${{ steps.version.outputs.VERSION }}.jar target/MiningLevels-v${{ steps.version.outputs.VERSION }}.jar
+
+      - name: Upload plugin JAR
+        uses: actions/upload-artifact@v4
+        with:
+          name: MiningLevels-v${{ steps.version.outputs.VERSION }}
+          path: target/MiningLevels-v${{ steps.version.outputs.VERSION }}.jar
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Add steps to produce MiningLevels-v<version>.jar as a downloadable artifact from CI builds, ready for GitHub releases.

https://claude.ai/code/session_01EyodQnKSvWcNzA6W8pCmyu