### PR TITLE
docs: update versions to Java 21, Paper 1.21, CrucialLib 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-[![User Wiki](https://img.shields.io/badge/Wiki-Users-blue)](https://github.com/ChafficPlugins/MiningLevels/wiki) [![](https://jitpack.io/v/ChafficPlugins/MiningLevels.svg)](https://github.com/ChafficPlugins/MiningLevels/releases/latest) [![Discord](https://img.shields.io/badge/Discord-Join-blue)](https://discord.gg/RYFamQzkcB)
+[![CI](https://github.com/ChafficPlugins/MiningLevels/actions/workflows/ci.yml/badge.svg)](https://github.com/ChafficPlugins/MiningLevels/actions/workflows/ci.yml) [![](https://jitpack.io/v/ChafficPlugins/MiningLevels.svg)](https://github.com/ChafficPlugins/MiningLevels/releases/latest) [![Discord](https://img.shields.io/badge/Discord-Join-blue)](https://discord.gg/RYFamQzkcB)
 
 # MiningLevels
 
-MiningLevels is a Spigot plugin that adds extra complexity to your mining experience.
+MiningLevels is a Paper/Spigot plugin that adds extra complexity to your mining experience.
 
 # Summary
 
@@ -18,11 +18,11 @@ MiningLevels is a Spigot plugin that adds extra complexity to your mining experi
 
 # Dependencies
 
-This project requires Java 16+.
+This project requires Java 21+.
 All dependencies are managed automatically by Maven.
 
-* Spigot
-    * Version: 1.18-R0.1-SNAPSHOT
-* CrucialAPI
-    * Version: 2.1.6
-    * [GitHub](https://github.com/Chafficui/CrucialAPI)
+* Paper API
+    * Version: 1.21
+* CrucialLib
+    * Version: 3.0.0
+    * [GitHub](https://github.com/ChafficPlugins/CrucialLib)

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,9 +21,9 @@ MiningLevels is a Spigot plugin that adds levels to your mining experience, brin
 
 ## Requirements
 
-- Java 16+
-- Spigot or Paper 1.18+
-- [CrucialLib](https://github.com/Chafficui/CrucialAPI)
+- Java 21+
+- Paper or Spigot 1.21+
+- [CrucialLib 3.0.0+](https://github.com/ChafficPlugins/CrucialLib)
 - [PlaceholderAPI](https://www.spigotmc.org/resources/placeholderapi.6245/) (optional, required for placeholders and level-up commands)
 
 ## License

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,7 +9,7 @@ You can download MiningLevels from:
 
 ## Setup
 
-1. **Install CrucialLib** – Download [CrucialLib](https://github.com/Chafficui/CrucialAPI) and place it in your server's `plugins/` folder. MiningLevels requires this dependency.
+1. **Install CrucialLib** – Download [CrucialLib](https://github.com/ChafficPlugins/CrucialLib) and place it in your server's `plugins/` folder. MiningLevels requires this dependency.
 2. **Install MiningLevels** – Place the MiningLevels `.jar` file in your server's `plugins/` folder.
 3. **Restart the server** – Restart (not reload) your server to let the plugin generate its default configuration files.
 4. **Configure** – Edit the generated config files in `plugins/MiningLevels/` to suit your server. See the [Configuration](configuration.md) guide for details.


### PR DESCRIPTION
Update README, website docs index, and installation guide to reflect current project requirements and fix outdated CrucialAPI references.

https://claude.ai/code/session_01EyodQnKSvWcNzA6W8pCmyu